### PR TITLE
use $(..) instead of `..`

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ $ docker rm tomcat
 ```
 Let's clean up, by removing all stopped containers.
 ```sh
-$ docker rm `docker ps -aq`
+$ docker rm "$(docker ps -aq)"
 ```
 
 ### Linking containers


### PR DESCRIPTION
Following advices of shellcheck.net, we can use $(..) instead of legacy `..` and quote it to prevent word splitting.
